### PR TITLE
Fix resizeMode on <Image />

### DIFF
--- a/ImageCapInset.android.js
+++ b/ImageCapInset.android.js
@@ -24,7 +24,7 @@ class ImageCapInset extends Component {
           style={{position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}
           capInsets={capInsets}
           source={normalizedSource}
-          resizeMode={Image.resizeMode.stretch}
+          resizeMode='stretch'
         />
         {children}
       </View>

--- a/ImageCapInset.ios.js
+++ b/ImageCapInset.ios.js
@@ -13,7 +13,7 @@ class ImageCapInset extends Component {
     return (
       <Image
         {...this.props}
-        resizeMode={Image.resizeMode.stretch}
+        resizeMode='stretch'
       />
     );
   }


### PR DESCRIPTION
React Native's Image component has a `resizeMode` prop. It used to have an "enum" hanging off the `Image` class, but it seems it's now just a union of strings. This PR fixes that.

Reference: https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageProps.js#L71