### PR TITLE
Fix crash caused by reload being called before mUri is set

### DIFF
--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -30,6 +30,10 @@ public class RCTImageCapInsetView extends ImageView {
     }
 
     public void reload() {
+	if (mUri == null) {
+            return;
+	}
+
         final String key = mUri + "-" + mCapInsets.toShortString();
         final RCTImageCache cache = RCTImageCache.getInstance();
 


### PR DESCRIPTION
Test Plan:
 - If you complete an exercise on android, the app will not crash
 - It seems like after the RN upgrade, something changed that's causing a race condition that results in reload being called before the Uri is set 