### PR TITLE
Copy synchronize bit from react-native

### DIFF
--- a/android/src/main/java/dk/madslee/imageCapInsets/utils/RCTResourceDrawableIdHelper.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/utils/RCTResourceDrawableIdHelper.java
@@ -23,15 +23,25 @@ public class RCTResourceDrawableIdHelper {
             return 0;
         }
         name = name.toLowerCase().replace("-", "_");
-        if (mResourceDrawableIdMap.containsKey(name)) {
-            return mResourceDrawableIdMap.get(name);
+
+        // name could be a resource id.
+        try {
+            return Integer.parseInt(name);
+        } catch (NumberFormatException e) {
+            // Do nothing.
         }
-        int id = context.getResources().getIdentifier(
-                name,
-                "drawable",
-                context.getPackageName());
-        mResourceDrawableIdMap.put(name, id);
-        return id;
+
+        synchronized (this) {
+            if (mResourceDrawableIdMap.containsKey(name)) {
+                return mResourceDrawableIdMap.get(name);
+            }
+            int id = context.getResources().getIdentifier(
+                    name,
+                    "drawable",
+                    context.getPackageName());
+            mResourceDrawableIdMap.put(name, id);
+            return id;
+        }
     }
 
     public @Nullable Drawable getResourceDrawable(Context context, @Nullable String name) {


### PR DESCRIPTION
This library copies a few classes from the React Native codebase. The `RCTResourceDrawableIdHelper` is a direct copy of [`ResourceDrawableIdHelper`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.java).

This PR simply updates the vendored class from React Native (which adds some thread safety so that we don't thrash on resolving the resource ID if it isn't in the cache already).
